### PR TITLE
Base extraction dir is now named from PAK, Directory structure from C2Ns is now recreated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # tsfp_unpak
 A python script for unpacking files from TimeSplitters : Future Perfect.
 
-Currently dumps out whatever it's found into an unpak folder it creates in the working directory.
+Currently dumps out whatever it's found into a folder named after the input PAK.
+
+A C2N file can be optionally provided in order to map CRCs to human readable paths.
 
 Usage:
 python unpak.py [pakfilename] [optional_c2n_filename]

--- a/unpak.py
+++ b/unpak.py
@@ -14,17 +14,21 @@ if (len(sys.argv) == 3):
         z = c2n.readlines()
         for n in z:
             crc,name = n.split()
-            c2n_file[crc] = name.replace('/', '_')
+            c2n_file[crc] = name;
 
 if (magic0 != 'P' or magic1 != '5' or magic2 != 'C' or magic3 != 'K'):
     print "This doesn't look like a pak file."
     sys.exit(-1)
 
-if (os.path.exists("./unpak") and os.path.isdir("./unpak")):
+pak_filename = os.path.basename( sys.argv[1] )
+base_dir = "./" + os.path.splitext(pak_filename)[0] + "/"
+
+if (os.path.exists(base_dir) and os.path.isdir(base_dir)):
     print "Output folder already exists."
     sys.exit(-1)
 
-os.makedirs("./unpak")
+
+os.makedirs(base_dir)
 
 f.seek(offset, 0)
 
@@ -44,9 +48,12 @@ for fi in file_infos:
     print ':' + outname + ':'
     if (c2n_file.has_key(outname)):
         outname = c2n_file[outname]
+    outname = base_dir + outname
+    if not ( os.path.exists( os.path.dirname(outname) ) and os.path.isdir( os.path.dirname(outname) ) ):
+        		os.makedirs(os.path.dirname(outname))
     if (fi[3] == 0):
         fd = f.read(fi[2])
-        with open("./unpak/" + outname, "wb") as o:
+        with open(outname, "wb") as o:
             o.write(fd)
     else:
         fd = f.read(fi[3])
@@ -55,7 +62,7 @@ for fi in file_infos:
             g.close()
         with gzip.open("temp.gz", "rb") as gz:
             data = gz.read()
-            with open("./unpak/" + outname, "wb") as o:
+            with open(outname, "wb") as o:
                 o.write(data)       
 
 f.close()


### PR DESCRIPTION
My Python is rather rusty but this should be stable.

I've updated the script to name the base extraction directory after the PAK it is working on instead of just "unpack", it also now properly recreates the folder structure from the C2N files.